### PR TITLE
html/.htaccess: Apache 2.4 compatibility

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -1,2 +1,7 @@
-order allow,deny
-allow from all
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+    Require all granted
+</IfModule>


### PR DESCRIPTION
Apache 2.4 changes the syntax of host filters. Update the .htaccess file in the html subdirectory to reflect this.
