### PR TITLE
Support Contao 4.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   },
   "require": {
     "php": ">=5.3",
-    "contao/core": ">=3.1,<4"
+    "contao/core-bundle": "~3.1 || ~4.4",
+    "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
   },
   "replace": {
     "contao-legacy/boxes4ward": "self.version"


### PR DESCRIPTION
This PR will allow to install boxes4ward in Contao 4. I set requirement to 4.4 as I only tested it in C4.4